### PR TITLE
convert negative numbers correctly

### DIFF
--- a/lib/ratio/float_conversion.ex
+++ b/lib/ratio/float_conversion.ex
@@ -23,9 +23,12 @@ defmodule Ratio.FloatConversion do
       iex> Ratio.FloatConversion.float_to_rational(1.1, 3)
       11 <|> 10
 
-
   """
-  def float_to_rational(float, max_decimals \\ @max_decimals) do
+  def float_to_rational(float, max_decimals \\ @max_decimals)
+  def float_to_rational(float, max_decimals) when float < 0.0 do
+    -float_to_rational(abs(float), max_decimals)
+  end
+  def float_to_rational(float, max_decimals) do
     float_to_intdec_tuple(float, max_decimals)
     |> intdec_tuple_to_rational
   end

--- a/test/ratio/float_conversion_test.exs
+++ b/test/ratio/float_conversion_test.exs
@@ -1,0 +1,9 @@
+defmodule Ratio.FloatConversionTest do
+  use ExUnit.Case, async: true
+
+  # use Ratio coerces negative floats to Ratios, so the below test needs to be run outside the Ratio.FloatConversion
+  # module.
+  test "float conversion for negative numbers" do
+    assert %Ratio{numerator: -11, denominator: 10} == Ratio.FloatConversion.float_to_rational(-1.1, 3)
+  end
+end


### PR DESCRIPTION
float_to_rational previously did not handle negative numbers correctly. This pull request addresses that issue and negative numbers are now converted correctly.