### PR TITLE
Add support for Decimals

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 elixir 1.10.0
-erlang 22.2
+erlang 22.0.2

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.7.2
-erlang 21.0.5
+elixir 1.10.0
+erlang 22.2

--- a/lib/ratio.ex
+++ b/lib/ratio.ex
@@ -140,6 +140,11 @@ defmodule Ratio do
 
   As Float-parsing is done by converting floats to a digit-list representation first, this is also far slower than when using integers or rationals.
 
+  ## Decimals
+
+  To use `Decimal` parameters, the [decimal](https://hex.pm/packages/decimal) library must
+  be configured in `mix.exs`.
+
   ## Examples
 
       iex> 1 <|> 2
@@ -173,28 +178,30 @@ defmodule Ratio do
     div(numerator, denominator)
   end
 
-  def (numerator = %Decimal{}) <|> (denominator = %Decimal{}) do
-    Ratio.DecimalConversion.decimal_to_rational(numerator)
-    |> div(Ratio.DecimalConversion.decimal_to_rational(denominator))
-  end
+  if Code.ensure_loaded?(Decimal) do
+    def (numerator = %Decimal{}) <|> (denominator = %Decimal{}) do
+      Ratio.DecimalConversion.decimal_to_rational(numerator)
+      |> div(Ratio.DecimalConversion.decimal_to_rational(denominator))
+    end
 
-  def (numerator = %Decimal{}) <|> denominator when is_float(denominator) do
-    Ratio.DecimalConversion.decimal_to_rational(numerator)
-    |> div(Ratio.FloatConversion.float_to_rational(denominator))
-  end
+    def (numerator = %Decimal{}) <|> denominator when is_float(denominator) do
+      Ratio.DecimalConversion.decimal_to_rational(numerator)
+      |> div(Ratio.FloatConversion.float_to_rational(denominator))
+    end
 
-  def numerator <|> (denominator = %Decimal{}) when is_float(numerator) do
-    Ratio.FloatConversion.float_to_rational(numerator)
-    |> div(Ratio.DecimalConversion.decimal_to_rational(denominator))
-  end
+    def numerator <|> (denominator = %Decimal{}) when is_float(numerator) do
+      Ratio.FloatConversion.float_to_rational(numerator)
+      |> div(Ratio.DecimalConversion.decimal_to_rational(denominator))
+    end
 
-  def (numerator = %Decimal{}) <|> denominator when is_integer(denominator) do
-    Ratio.DecimalConversion.decimal_to_rational(numerator)
-    |> div(denominator)
-  end
+    def (numerator = %Decimal{}) <|> denominator when is_integer(denominator) do
+      Ratio.DecimalConversion.decimal_to_rational(numerator)
+      |> div(denominator)
+    end
 
-  def numerator <|> (denominator = %Decimal{}) when is_integer(numerator) do
-    div(Ratio.DecimalConversion.decimal_to_rational(numerator), denominator)
+    def numerator <|> (denominator = %Decimal{}) when is_integer(numerator) do
+      div(Ratio.DecimalConversion.decimal_to_rational(numerator), denominator)
+    end
   end
 
   def numerator <|> denominator do
@@ -206,6 +213,9 @@ defmodule Ratio do
   Useful when `<|>` is not available (for instance, when already in use by another module)
 
   Not imported when calling `use Ratio`, so always call it as `Ratio.new(a, b)`
+
+  To use `Decimal` parameters, the [decimal](https://hex.pm/packages/decimal) library must
+  be configured in `mix.exs`.
 
   ## Examples
 
@@ -221,17 +231,19 @@ defmodule Ratio do
   """
   def new(numerator, denominator \\ 1)
 
-  def new(%Decimal{} = decimal, 1) do
-    Ratio.DecimalConversion.decimal_to_rational(decimal)
-  end
+  if Code.ensure_loaded?(Decimal) do
+    def new(%Decimal{} = decimal, 1) do
+      Ratio.DecimalConversion.decimal_to_rational(decimal)
+    end
 
-  def new(%Decimal{} = numerator, %Decimal{} = denominator) do
-    Ratio.DecimalConversion.decimal_to_rational(numerator) <|>
-    Ratio.DecimalConversion.decimal_to_rational(denominator)
-  end
+    def new(%Decimal{} = numerator, %Decimal{} = denominator) do
+      Ratio.DecimalConversion.decimal_to_rational(numerator) <|>
+      Ratio.DecimalConversion.decimal_to_rational(denominator)
+    end
 
-  def new(numerator, %Decimal{} = denominator) do
-    numerator <|> Ratio.DecimalConversion.decimal_to_rational(denominator)
+    def new(numerator, %Decimal{} = denominator) do
+      numerator <|> Ratio.DecimalConversion.decimal_to_rational(denominator)
+    end
   end
 
   def new(numerator, denominator) do

--- a/lib/ratio.ex
+++ b/lib/ratio.ex
@@ -215,7 +215,7 @@ defmodule Ratio do
       1 <|> 3
       iex> Ratio.new(1.5, 4)
       3 <|> 8
-      iex> Ratio.DecimalConversion.decimal_to_rational(Decimal.new("123.456"))
+      iex> Ratio.new(Decimal.new("123.456"))
       15432 <|> 125
 
   """

--- a/lib/ratio.ex
+++ b/lib/ratio.ex
@@ -173,6 +173,30 @@ defmodule Ratio do
     div(numerator, denominator)
   end
 
+  def (numerator = %Decimal{}) <|> (denominator = %Decimal{}) do
+    Ratio.DecimalConversion.decimal_to_rational(numerator)
+    |> div(Ratio.DecimalConversion.decimal_to_rational(denominator))
+  end
+
+  def (numerator = %Decimal{}) <|> denominator when is_float(denominator) do
+    Ratio.DecimalConversion.decimal_to_rational(numerator)
+    |> div(Ratio.FloatConversion.float_to_rational(denominator))
+  end
+
+  def numerator <|> (denominator = %Decimal{}) when is_float(numerator) do
+    Ratio.FloatConversion.float_to_rational(numerator)
+    |> div(Ratio.DecimalConversion.decimal_to_rational(denominator))
+  end
+
+  def (numerator = %Decimal{}) <|> denominator when is_integer(denominator) do
+    Ratio.DecimalConversion.decimal_to_rational(numerator)
+    |> div(denominator)
+  end
+
+  def numerator <|> (denominator = %Decimal{}) when is_integer(numerator) do
+    div(Ratio.DecimalConversion.decimal_to_rational(numerator), denominator)
+  end
+
   def numerator <|> denominator do
     div(numerator, denominator)
   end
@@ -191,8 +215,19 @@ defmodule Ratio do
       1 <|> 3
       iex> Ratio.new(1.5, 4)
       3 <|> 8
+      iex> Ratio.DecimalConversion.decimal_to_rational(Decimal.new("123.456"))
+      15432 <|> 125
+
   """
-  def new(numerator, denominator \\ 1), do: numerator <|> denominator
+  def new(numerator, denominator \\ 1)
+
+  def new(%Decimal{} = decimal, 1) do
+    Ratio.DecimalConversion.decimal_to_rational(decimal)
+  end
+
+  def new(numerator, denominator) do
+    numerator <|> denominator
+  end
 
   @doc """
   Returns the absolute version of the given number (which might be an integer, float or Rational).

--- a/lib/ratio.ex
+++ b/lib/ratio.ex
@@ -225,6 +225,15 @@ defmodule Ratio do
     Ratio.DecimalConversion.decimal_to_rational(decimal)
   end
 
+  def new(%Decimal{} = numerator, %Decimal{} = denominator) do
+    Ratio.DecimalConversion.decimal_to_rational(numerator) <|>
+    Ratio.DecimalConversion.decimal_to_rational(denominator)
+  end
+
+  def new(numerator, %Decimal{} = denominator) do
+    numerator <|> Ratio.DecimalConversion.decimal_to_rational(denominator)
+  end
+
   def new(numerator, denominator) do
     numerator <|> denominator
   end

--- a/lib/ratio/coerce.ex
+++ b/lib/ratio/coerce.ex
@@ -5,3 +5,15 @@ Coerce.defcoercion(Ratio, Decimal) do
     {ratio, Ratio.DecimalConversion.decimal_to_rational(decimal)}
   end
 end
+
+Coerce.defcoercion(Ratio, Integer) do
+  def coerce(ratio, integer) do
+    {ratio, Ratio.new(integer)}
+  end
+end
+
+Coerce.defcoercion(Ratio, Float) do
+  def coerce(ratio, float) do
+    {ratio, Ratio.new(float)}
+  end
+end

--- a/lib/ratio/coerce.ex
+++ b/lib/ratio/coerce.ex
@@ -1,11 +1,5 @@
 require Coerce
 
-Coerce.defcoercion(Ratio, Decimal) do
-  def coerce(ratio, decimal) do
-    {ratio, Ratio.DecimalConversion.decimal_to_rational(decimal)}
-  end
-end
-
 Coerce.defcoercion(Ratio, Integer) do
   def coerce(ratio, integer) do
     {ratio, Ratio.new(integer)}
@@ -15,5 +9,11 @@ end
 Coerce.defcoercion(Ratio, Float) do
   def coerce(ratio, float) do
     {ratio, Ratio.new(float)}
+  end
+end
+
+Coerce.defcoercion(Ratio, Decimal) do
+  def coerce(ratio, decimal) do
+    {ratio, Ratio.DecimalConversion.decimal_to_rational(decimal)}
   end
 end

--- a/lib/ratio/coerce.ex
+++ b/lib/ratio/coerce.ex
@@ -1,0 +1,7 @@
+require Coerce
+
+Coerce.defcoercion(Ratio, Decimal) do
+  def coerce(ratio, decimal) do
+    {ratio, Ratio.DecimalConversion.decimal_to_rational(decimal)}
+  end
+end

--- a/lib/ratio/decimal_conversion.ex
+++ b/lib/ratio/decimal_conversion.ex
@@ -1,0 +1,28 @@
+defmodule Ratio.DecimalConversion do
+  use Ratio
+
+  def decimal_to_rational(%Decimal{coef: coef, exp: 0}) do
+    Ratio.new(coef, 1)
+  end
+
+  def decimal_to_rational(%Decimal{exp: exp} = decimal) when exp < 0 do
+    %Decimal{coef: coef, exp: exp, sign: sign} = Decimal.normalize(decimal)
+
+    {integer, decimal} =
+      coef
+      |> Integer.to_string
+      |> String.split_at(exp)
+
+    decimal_len = String.length(integer)
+    numerator = Ratio.pow(10, decimal_len)
+    integer = String.to_integer(integer)
+    decimal = String.to_integer(decimal)
+
+    (sign * (integer * numerator + decimal)) <|> numerator
+  end
+
+  def decimal_to_rational(%Decimal{} = decimal) do
+    %Decimal{coef: coef, exp: exp, sign: sign} = Decimal.normalize(decimal)
+    (sign * (coef * Ratio.pow(10, exp))) <|> 1
+  end
+end

--- a/lib/ratio/decimal_conversion.ex
+++ b/lib/ratio/decimal_conversion.ex
@@ -1,28 +1,41 @@
-defmodule Ratio.DecimalConversion do
-  use Ratio
+if Code.ensure_loaded?(Decimal) do
+  defmodule Ratio.DecimalConversion do
+    use Ratio
 
-  def decimal_to_rational(%Decimal{coef: coef, exp: 0}) do
-    Ratio.new(coef, 1)
+    def decimal_to_rational(%Decimal{coef: coef, exp: 0}) do
+      Ratio.new(coef, 1)
+    end
+
+    def decimal_to_rational(%Decimal{exp: exp} = decimal) when exp < 0 do
+      %Decimal{coef: coef, exp: exp, sign: sign} = normalize_decimal(decimal)
+
+      {integer, decimal} =
+        coef
+        |> Integer.to_string
+        |> String.split_at(exp)
+
+      decimal_len = String.length(integer)
+      numerator = Ratio.pow(10, decimal_len)
+      integer = String.to_integer(integer)
+      decimal = String.to_integer(decimal)
+
+      (sign * (integer * numerator + decimal)) <|> numerator
+    end
+
+    def decimal_to_rational(%Decimal{} = decimal) do
+      %Decimal{coef: coef, exp: exp, sign: sign} = normalize_decimal(decimal)
+      (sign * (coef * Ratio.pow(10, exp))) <|> 1
+    end
+
+    if function_exported?(Decimal, :normalize, 1) do
+      defp normalize_decimal(decimal) do
+        Decimal.normalize(decimal)
+      end
+    else
+      defp normalize_decimal(decimal) do
+        Decimal.reduce(decimal)
+      end
+    end
   end
 
-  def decimal_to_rational(%Decimal{exp: exp} = decimal) when exp < 0 do
-    %Decimal{coef: coef, exp: exp, sign: sign} = Decimal.normalize(decimal)
-
-    {integer, decimal} =
-      coef
-      |> Integer.to_string
-      |> String.split_at(exp)
-
-    decimal_len = String.length(integer)
-    numerator = Ratio.pow(10, decimal_len)
-    integer = String.to_integer(integer)
-    decimal = String.to_integer(decimal)
-
-    (sign * (integer * numerator + decimal)) <|> numerator
-  end
-
-  def decimal_to_rational(%Decimal{} = decimal) do
-    %Decimal{coef: coef, exp: exp, sign: sign} = Decimal.normalize(decimal)
-    (sign * (coef * Ratio.pow(10, exp))) <|> 1
-  end
 end

--- a/lib/ratio/float_conversion.ex
+++ b/lib/ratio/float_conversion.ex
@@ -2,7 +2,6 @@ defmodule Ratio.FloatConversion do
   use Ratio
 
   @max_decimals Application.get_env(:ratio, :max_float_to_rational_digits)
-  IO.puts(Application.get_env(:ratio, :max_float_to_rational_digits))
 
   @doc """
   Converts a float to a rational number.

--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,8 @@ defmodule Rational.Mixfile do
       # Documentation for Hex.pm
       {:ex_doc, "~> 0.20", only: [:dev]},
       # Generic arithmetic dispatching.
-      {:numbers, "~> 5.1.0"}
+      {:numbers, "~> 5.1.0"},
+      {:decimal, "~> 1.9-rc or ~> 2.0", override: true}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,7 @@ defmodule Rational.Mixfile do
       # Documentation for Hex.pm
       {:ex_doc, "~> 0.20", only: [:dev]},
       # Generic arithmetic dispatching.
-      {:numbers, "~> 5.2.0"}
+      {:numbers, "~> 5.2.0"},
       # If Decimal number support is required
       {:decimal, "~> 1.6 or ~> 2.0", optional: true}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,9 @@ defmodule Rational.Mixfile do
       {:ex_doc, "~> 0.20", only: [:dev]},
       # Generic arithmetic dispatching.
       {:numbers, "~> 5.1.0"},
-      {:decimal, "~> 1.9-rc or ~> 2.0", override: true}
+
+      # If Decimal number support is required
+      {:decimal, "~> 1.6 or ~> 2.0", optional: true}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
   "coerce": {:hex, :coerce, "1.0.1", "211c27386315dc2894ac11bc1f413a0e38505d808153367bd5c6e75a4003d096", [:mix], [], "hexpm"},
-  "decimal": {:hex, :decimal, "1.9.0-rc.0", "63aeb71a13aad2c766976abdadce619c83387b04f8403cbb8d0ea1cc4c707d03", [:mix], [], "hexpm"},
+  "decimal": {:hex, :decimal, "1.8.1", "a4ef3f5f3428bdbc0d35374029ffcf4ede8533536fa79896dd450168d9acdf3c", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.21.2", "caca5bc28ed7b3bdc0b662f8afe2bee1eedb5c3cf7b322feeeb7c6ebbde089d6", [:mix], [{:earmark, "~> 1.3.3 or ~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
   "coerce": {:hex, :coerce, "1.0.1", "211c27386315dc2894ac11bc1f413a0e38505d808153367bd5c6e75a4003d096", [:mix], [], "hexpm"},
-  "decimal": {:hex, :decimal, "1.1.1"},
+  "decimal": {:hex, :decimal, "1.9.0-rc.0", "63aeb71a13aad2c766976abdadce619c83387b04f8403cbb8d0ea1cc4c707d03", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.21.2", "caca5bc28ed7b3bdc0b662f8afe2bee1eedb5c3cf7b322feeeb7c6ebbde089d6", [:mix], [{:earmark, "~> 1.3.3 or ~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},

--- a/test/ratio_test.exs
+++ b/test/ratio_test.exs
@@ -8,11 +8,13 @@ defmodule RatioTest do
     assert 1 <|> 3 == %Ratio{numerator: 1, denominator: 3}
   end
 
-  test "decimal conversion" do
-    assert 15432 <|> 125 == Ratio.new(Decimal.new("123.456"))
-    assert 617 <|> 2839 == Ratio.new(Decimal.new("1234"), Decimal.new("5678"))
-    assert 617 <|> 2839 == Ratio.new(1234, Decimal.new("5678"))
-    assert 617 <|> 2839 == Ratio.new(Decimal.new("1234"), 5678)
+  if Code.ensure_loaded?(Decimal) do
+    test "decimal conversion" do
+      assert 15432 <|> 125 == Ratio.new(Decimal.new("123.456"))
+      assert 617 <|> 2839 == Ratio.new(Decimal.new("1234"), Decimal.new("5678"))
+      assert 617 <|> 2839 == Ratio.new(1234, Decimal.new("5678"))
+      assert 617 <|> 2839 == Ratio.new(Decimal.new("1234"), 5678)
+    end
   end
 
   test "reject _ <|> 0" do

--- a/test/ratio_test.exs
+++ b/test/ratio_test.exs
@@ -8,6 +8,10 @@ defmodule RatioTest do
     assert 1 <|> 3 == %Ratio{numerator: 1, denominator: 3}
   end
 
+  test "decimal conversion" do
+    assert 15432 <|> 125 == Ratio.new(Decimal.new("123.456"))
+  end
+
   test "reject _ <|> 0" do
     assert_raise ArithmeticError, fn -> 1 <|> 0 end
     assert_raise ArithmeticError, fn -> 1234 <|> 0 end

--- a/test/ratio_test.exs
+++ b/test/ratio_test.exs
@@ -10,6 +10,9 @@ defmodule RatioTest do
 
   test "decimal conversion" do
     assert 15432 <|> 125 == Ratio.new(Decimal.new("123.456"))
+    assert 617 <|> 2839 == Ratio.new(Decimal.new("1234"), Decimal.new("5678"))
+    assert 617 <|> 2839 == Ratio.new(1234, Decimal.new("5678"))
+    assert 617 <|> 2839 == Ratio.new(Decimal.new("1234"), 5678)
   end
 
   test "reject _ <|> 0" do


### PR DESCRIPTION
Forgive the unexpected PR for this but I had an hour free to put this together.

1. Add `Ratio.new/2` support for `Decimal`
2. Add support for `Decimal <|> number` and `number <|> Decimal`
3. Remove the spurious `IO.puts/1` in `Ratio.FloatConversion`
4. Add tests for `Ratio.new/2` and `<|>` with a Decimal
5. Added dependency for Decimal. This could be made optional. I also have conformed to the Decimal `1.9` API, in particular `Decimal.normalize/1` which replaces the deprecated `Decimal.reduce/1`. This needs review before any release strategy. In part it may depend on when either `1.9` or `2.0` are released since they are both "required" to properly support Elixir 1.10
