### PR TITLE
Version 3

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -2,5 +2,6 @@
   inputs: [
     "{lib,test,config}/**/*.{ex,exs}",
     "*.exs"
-  ]
+  ],
+  import_deps: [:stream_data]
 ]

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 elixir 1.10.0
-erlang 22.0.2
+erlang 22.0.7

--- a/lib/ratio.ex
+++ b/lib/ratio.ex
@@ -454,7 +454,8 @@ defmodule Ratio do
   @spec to_float_error(t | number) :: {float, error} when error: t | number
   def to_float_error(number) do
     float = to_float(number)
-    {float, float - number}
+    error = Ratio.sub(Ratio.new(float), number)
+    {float, error}
   end
 
 

--- a/lib/ratio.ex
+++ b/lib/ratio.ex
@@ -351,7 +351,7 @@ defmodule Ratio do
       iex> 2 - 3
       -1
       iex> 2.3 - 0.3
-      2
+      2 <|> 1
       iex> 2.3 - 0.1
       11 <|> 5
       iex> (2 <|> 3) - (1 <|> 5)
@@ -404,8 +404,7 @@ defmodule Ratio do
   Unary plus. Returns *num*.
   Coerces the number to a rational if it is a float.
   """
-  def +num when is_integer(num), do: Kernel.+(num)
-  def +num when is_float(num), do: Ratio.FloatConversion.float_to_rational(num)
+  def +num when is_integer(num) or is_float(num), do: Kernel.+(num)
   def +num, do: num
 
   @doc """
@@ -665,7 +664,7 @@ defmodule Ratio do
   def pow(x, n)
 
   # Convert Float to Rational.
-  def pow(x, n) when is_float(x), do: pow(Ratio.FloatConversion.float_to_rational(x), n)
+  # def pow(x, n) when is_float(x), do: pow(Ratio.FloatConversion.float_to_rational(x), n)
 
   # Small powers
   def pow(x, 1), do: x
@@ -678,8 +677,12 @@ defmodule Ratio do
   defp do_pow(_x, 0, y), do: y
   defp do_pow(x, 1, y), do: x * y
   defp do_pow(x, n, y) when Kernel.<(n, 0), do: do_pow(1 / x, Kernel.-(n), y)
-  defp do_pow(x, n, y) when rem(n, 2) |> Kernel.==(0), do: do_pow(x * x, div(n, 2), y)
-  defp do_pow(x, n, y), do: do_pow(x * x, div(n - 1, 2), x * y)
+  defp do_pow(x, n, y) when rem(n, 2) |> Kernel.==(0) do
+    do_pow(x * x, Kernel.div(n, 2), y)
+  end
+  defp do_pow(x, n, y) do
+    do_pow(x * x, Kernel.div(n - 1, 2), x * y)
+  end
 
   @doc """
   Converts the given *number* to a Float. As floats do not have arbitrary precision, this operation is generally not reversible.

--- a/lib/ratio.ex
+++ b/lib/ratio.ex
@@ -158,9 +158,7 @@ defmodule Ratio do
   end
 
   def numerator <|> denominator when is_integer(numerator) and is_integer(denominator) do
-    %Ratio{numerator: numerator, denominator: denominator}
-    |> simplify
-    |> remove_denominator_if_integer
+    simplify(%Ratio{numerator: numerator, denominator: denominator})
   end
 
   def numerator <|> denominator when is_float(numerator) do
@@ -390,7 +388,7 @@ defmodule Ratio do
       iex> -10
       -10
       iex> -10.0
-      -10
+      -10.0
       iex> -10.1
       -101 <|> 10
       iex> -(5 <|> 3)
@@ -499,7 +497,7 @@ defmodule Ratio do
       iex> (2 <|> 3) / (8 <|> 5)
       5 <|> 12
       iex> 2.0 / 1.0
-      2
+      2 <|> 1
 
   """
   def a / b
@@ -704,7 +702,7 @@ defmodule Ratio do
   ## Examples
 
       iex> Ratio.to_float_error(Ratio.new(1, 2))
-      {0.5, 0}
+      {0.5, 0 <|> 1}
       iex> Ratio.to_float_error(Ratio.new(2, 3))
       {0.6666666666666666, 1 <|> 30000000000}
   """
@@ -718,7 +716,11 @@ defmodule Ratio do
   Check if a number is a rational number.
   Returns false if the number is an integer, float or any other type.
 
-  To check if a float representation will result in a rational number, combine it with the unary plus operation:
+  Note that even rational numbers that represent 'whole' numbers (i.e. have a `1` as numerator)
+  are considered rational numbers.
+
+  NOTE this function will be deprecated or removed from V3.
+
 
   ## Examples
 
@@ -733,9 +735,9 @@ defmodule Ratio do
       iex>Ratio.is_rational?(10 <|> 3)
       true
       iex>Ratio.is_rational?(10 <|> 5)
-      false
-      iex>Ratio.is_rational?(+20.234)
       true
+      iex>Ratio.is_rational?(+20.234)
+      false
       iex>Ratio.is_rational?(+20.0)
       false
 
@@ -745,19 +747,16 @@ defmodule Ratio do
 
   @doc """
   Returns a binstring representation of the Rational number.
-  If the denominator is `1`, it will be printed as a normal (integer) number.
+  If the denominator is `1` it will still be printed in the `a <|> 1` format.
 
   ## Examples
 
       iex> Ratio.to_string 10 <|> 7
       "10 <|> 7"
+      iex> Ratio.to_string 10 <|> 2
+      "5 <|> 1"
   """
   def to_string(rational)
-
-  def to_string(%Ratio{numerator: numerator, denominator: denominator})
-      when denominator |> Kernel.==(1) do
-    "#{numerator}"
-  end
 
   def to_string(%Ratio{numerator: numerator, denominator: denominator}) do
     "#{numerator} <|> #{denominator}"
@@ -785,11 +784,11 @@ defmodule Ratio do
     new_denominator = Kernel.div(denominator, gcdiv)
     {new_denominator, numerator} = normalize_denom_num(new_denominator, numerator)
 
-    if new_denominator == 1 do
-      Kernel.div(numerator, gcdiv)
-    else
+    # if new_denominator == 1 do
+    #   Kernel.div(numerator, gcdiv)
+    # else
       %Ratio{numerator: Kernel.div(numerator, gcdiv), denominator: new_denominator}
-    end
+    # end
   end
 
   defp normalize_denom_num(denominator, numerator) do
@@ -799,11 +798,6 @@ defmodule Ratio do
       {denominator, numerator}
     end
   end
-
-  # Returns an integer if the result is of the form _ <|> 1
-  defp remove_denominator_if_integer(rational)
-  defp remove_denominator_if_integer(%Ratio{numerator: numerator, denominator: 1}), do: numerator
-  defp remove_denominator_if_integer(rational), do: rational
 
   # Calculates the Greatest Common denominator of two numbers.
   defp gcd(a, 0), do: abs(a)

--- a/lib/ratio.ex
+++ b/lib/ratio.ex
@@ -161,8 +161,12 @@ defmodule Ratio do
     end
   end
 
-  def numerator <|> denominator do
-    div(numerator, denominator)
+  def numerator <|> (denominator = %Ratio{}) when is_integer(numerator) do
+    div(%Ratio{numerator: numerator, denominator: 1}, denominator)
+  end
+
+  def (numerator = %Ratio{}) <|> denominator when is_integer(denominator) do
+    div(numerator, %Ratio{numerator: 1, denominator: denominator})
   end
 
   @doc """

--- a/lib/ratio.ex
+++ b/lib/ratio.ex
@@ -436,38 +436,31 @@ defmodule Ratio do
     {float, float - number}
   end
 
+  if function_exported?(:erlang, :map_get, 2) do
+
   @doc """
-  Check if a number is a rational number.
-  Returns false if the number is an integer, float or any other type.
+  Guard-safe check to see whether something is a ratioal struct.
 
-  Note that even rational numbers that represent 'whole' numbers (i.e. have a `1` as numerator)
-  are considered rational numbers.
+  This function relies on `:erlang.map_get` and is therefore only available in newer OTP versions.
 
-  NOTE this function will be deprecated or removed from V3.
-
-
-  ## Examples
-
-      iex>Ratio.is_rational?(10)
-      false
-      iex>Ratio.is_rational?("foo")
-      false
-      iex>Ratio.is_rational?(10.0)
-      false
-      iex>Ratio.is_rational?(10.234)
-      false
-      iex>Ratio.is_rational?(10 <|> 3)
-      true
-      iex>Ratio.is_rational?(10 <|> 5)
-      true
-      iex>Ratio.is_rational?(+20.234)
-      false
-      iex>Ratio.is_rational?(+20.0)
-      false
-
+  iex> is_rational(1 <|> 2)
+  true
+  is_rational(Ratio.new(10))
+  true
+  iex> is_rational(42)
+  false
+  iex> is_rational(%{})
+  false
+  iex> is_rational("My quick brown fox")
+  false
   """
   def is_rational?(%Ratio{}), do: true
   def is_rational?(_), do: false
+
+
+  defguard is_rational(val) when is_struct(val) and is_map_key(val, :__struct__) and :erlang.map_get(:__struct__, val) == __MODULE__
+
+  end
 
   @doc """
   Returns a binstring representation of the Rational number.

--- a/lib/ratio/decimal_conversion.ex
+++ b/lib/ratio/decimal_conversion.ex
@@ -1,6 +1,6 @@
 if Code.ensure_loaded?(Decimal) do
   defmodule Ratio.DecimalConversion do
-    use Ratio
+    import Ratio, only: [<|>: 2]
 
     def decimal_to_rational(%Decimal{coef: coef, exp: 0}) do
       Ratio.new(coef, 1)

--- a/lib/ratio/decimal_conversion.ex
+++ b/lib/ratio/decimal_conversion.ex
@@ -7,7 +7,7 @@ if Code.ensure_loaded?(Decimal) do
 
     def decimal_to_rational(%Decimal{coef: coef, exp: exp, sign: sign}) do
       numerator = coef * sign
-      denominator = Ratio.pow(10, exp * -1)
+      denominator = Ratio.pow(Ratio.new(10), exp * -1)
       Ratio.new(numerator, denominator)
     end
   end

--- a/lib/ratio/float_conversion.ex
+++ b/lib/ratio/float_conversion.ex
@@ -1,5 +1,5 @@
 defmodule Ratio.FloatConversion do
-  use Ratio
+  import Ratio, only: [<|>: 2]
 
   @max_decimals Application.get_env(:ratio, :max_float_to_rational_digits)
 

--- a/lib/ratio/float_conversion.ex
+++ b/lib/ratio/float_conversion.ex
@@ -26,7 +26,7 @@ defmodule Ratio.FloatConversion do
   def float_to_rational(float, max_decimals \\ @max_decimals)
 
   def float_to_rational(float, max_decimals) when Kernel.<(float, 0.0) do
-    -float_to_rational(abs(float), max_decimals)
+    Ratio.minus(float_to_rational(abs(float), max_decimals))
   end
 
   def float_to_rational(float, max_decimals) do

--- a/lib/ratio/float_conversion.ex
+++ b/lib/ratio/float_conversion.ex
@@ -48,7 +48,7 @@ defmodule Ratio.FloatConversion do
   # Changes {'1', '234'} to (1234 <|> 1000)
   defp intdec_tuple_to_rational({integer_list, decimal_list}) do
     decimal_len = Enum.count(decimal_list)
-    numerator = Ratio.pow(10, decimal_len)
+    numerator = Numbers.pow(10, decimal_len)
     integer = List.to_integer(integer_list)
     decimal = List.to_integer(decimal_list)
 

--- a/lib/ratio/float_conversion.ex
+++ b/lib/ratio/float_conversion.ex
@@ -14,7 +14,7 @@ defmodule Ratio.FloatConversion do
   ## Examples
 
       iex> Ratio.FloatConversion.float_to_rational(10.0)
-      10
+      10 <|> 1
       iex> Ratio.FloatConversion.float_to_rational(13.5)
       27 <|> 2
       iex> Ratio.FloatConversion.float_to_rational(1.1, 100)

--- a/mix.exs
+++ b/mix.exs
@@ -19,11 +19,17 @@ defmodule Rational.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
+    extra_applications =
+      case Mix.env() do
+        :test -> [:stream_data]
+        _ -> []
+      end
     [
       applications: [
         :logger,
         :numbers
-      ]
+      ],
+      extra_applications: extra_applications
     ]
   end
 
@@ -45,7 +51,8 @@ defmodule Rational.Mixfile do
       # Generic arithmetic dispatching.
       {:numbers, "~> 5.2.0"},
       # If Decimal number support is required
-      {:decimal, "~> 1.6 or ~> 2.0", optional: true}
+      {:decimal, "~> 1.6 or ~> 2.0", optional: true},
+      {:stream_data, "~> 0.1", only: :test},
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -7,4 +7,5 @@
   "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.3", "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm"},
   "numbers": {:hex, :numbers, "5.2.0", "34515afc34b005b347128ea1bf5a5807f69b07836d9f09611471282e04adabf3", [:mix], [{:coerce, "~> 1.0", [hex: :coerce, repo: "hexpm", optional: false]}, {:decimal, "~> 1.5", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  "stream_data": {:hex, :stream_data, "0.4.3", "62aafd870caff0849a5057a7ec270fad0eb86889f4d433b937d996de99e3db25", [:mix], [], "hexpm"},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -2,7 +2,7 @@
   "coerce": {:hex, :coerce, "1.0.1", "211c27386315dc2894ac11bc1f413a0e38505d808153367bd5c6e75a4003d096", [:mix], [], "hexpm"},
   "decimal": {:hex, :decimal, "1.8.1", "a4ef3f5f3428bdbc0d35374029ffcf4ede8533536fa79896dd450168d9acdf3c", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.21.2", "caca5bc28ed7b3bdc0b662f8afe2bee1eedb5c3cf7b322feeeb7c6ebbde089d6", [:mix], [{:earmark, "~> 1.3.3 or ~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.21.3", "857ec876b35a587c5d9148a2512e952e24c24345552259464b98bfbb883c7b42", [:mix], [{:earmark, "~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.3", "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm"},

--- a/mix.lock
+++ b/mix.lock
@@ -6,6 +6,6 @@
   "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.3", "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm"},
-  "numbers": {:hex, :numbers, "5.2.0", "34515afc34b005b347128ea1bf5a5807f69b07836d9f09611471282e04adabf3", [:mix], [{:coerce, "~> 1.0", [hex: :coerce, repo: "hexpm", optional: false]}, {:decimal, "~> 1.5", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  "numbers": {:hex, :numbers, "5.2.1", "8a6e9eeacfb19f4ac30a52c304f565dc53f8e0813b7193812a5b15b93210780c", [:mix], [{:coerce, "~> 1.0", [hex: :coerce, repo: "hexpm", optional: false]}, {:decimal, "~> 1.5", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "stream_data": {:hex, :stream_data, "0.4.3", "62aafd870caff0849a5057a7ec270fad0eb86889f4d433b937d996de99e3db25", [:mix], [], "hexpm"},
 }

--- a/test/ratio/decimal_conversion_test.exs
+++ b/test/ratio/decimal_conversion_test.exs
@@ -1,17 +1,17 @@
 defmodule Ratio.DecimalConversionTest do
   use ExUnit.Case, async: true
 
-  use Ratio
+  import Ratio, only: [<|>: 2]
 
   @test_cases [
-    {Decimal.new("-1230"), -1230},
-    {Decimal.new("-123"), -123},
+    {Decimal.new("-1230"), Ratio.new(-1230)},
+    {Decimal.new("-123"), Ratio.new(-123)},
     {Decimal.new("-12.3"), -123 <|> 10},
     {Decimal.new("-1.23"), -123 <|> 100},
     {Decimal.new("-0.123"), -123 <|> 1000},
     {Decimal.new("-0.0123"), -123 <|> 10000},
-    {Decimal.new("1230"), 1230},
-    {Decimal.new("123"), 123},
+    {Decimal.new("1230"), Ratio.new(1230)},
+    {Decimal.new("123"), Ratio.new(123)},
     {Decimal.new("12.3"), 123 <|> 10},
     {Decimal.new("1.23"), 123 <|> 100},
     {Decimal.new("0.123"), 123 <|> 1000},

--- a/test/ratio/numbers_test.exs
+++ b/test/ratio/numbers_test.exs
@@ -1,6 +1,6 @@
 defmodule Ratio.NumbersTest do
   use ExUnit.Case, async: true
-  use Ratio, override_math: false
+  # import Ratio, only: [<|>: 2]
 
   alias Numbers, as: N
 

--- a/test/ratio/numbers_test.exs
+++ b/test/ratio/numbers_test.exs
@@ -6,15 +6,19 @@ defmodule Ratio.NumbersTest do
 
   @unary_operations [:abs, :minus, :to_float]
   for operation <- @unary_operations do
-    test "Numbers.#{operation}/1 has the same result as running Ratio.#{operation}/1" do
+    test "Numbers.#{operation}/1 has the same result as running Ratio.#{operation}/1 (except casting)" do
       assert Ratio.unquote(operation)(Ratio.new(1, 3)) == N.unquote(operation)(Ratio.new(1, 3))
     end
   end
 
-  @binary_operations [:add, :sub, :mult, :div, :pow]
+  @binary_operations [:add, :sub, :mult, :div]
   for operation <- @binary_operations do
-    test "Numbers.#{operation}/2 has the same result as running Ratio.#{operation}/2" do
-      assert Ratio.unquote(operation)(Ratio.new(1, 2), 3) == N.unquote(operation)(Ratio.new(1, 2), 3)
+    test "Numbers.#{operation}/2 has the same result as running Ratio.#{operation}/2 (except casting)" do
+      assert Ratio.unquote(operation)(Ratio.new(1, 2), Ratio.new(3)) == N.unquote(operation)(Ratio.new(1, 2), Ratio.new(3))
     end
+  end
+
+  test "Numbers.pow/2 has the same result as running Ratio.pos/2 (except casting)" do
+    assert Ratio.pow(Ratio.new(1, 2), 3) == N.pow(Ratio.new(1, 2), 3)
   end
 end

--- a/test/ratio/numbers_test.exs
+++ b/test/ratio/numbers_test.exs
@@ -1,8 +1,11 @@
 defmodule Ratio.NumbersTest do
   use ExUnit.Case, async: true
-  # import Ratio, only: [<|>: 2]
+  import Ratio, only: [is_rational: 1]
+  use ExUnitProperties
+  import TestHelper
 
   alias Numbers, as: N
+  use Numbers, overload_operators: true
 
   @unary_operations [:abs, :minus, :to_float]
   for operation <- @unary_operations do
@@ -20,5 +23,120 @@ defmodule Ratio.NumbersTest do
 
   test "Numbers.pow/2 has the same result as running Ratio.pos/2 (except casting)" do
     assert Ratio.pow(Ratio.new(1, 2), 3) == N.pow(Ratio.new(1, 2), 3)
+  end
+
+
+
+  property "Addition is closed" do
+    check all a <- rational_generator(),
+      b <- rational_generator() do
+      assert is_rational(a + b)
+    end
+  end
+
+  property "Addition is commutative" do
+    check all a <- rational_generator(),
+      b <- rational_generator() do
+      assert a + b == b + a
+    end
+  end
+
+  property "Addition is associative" do
+    check all a <- rational_generator(),
+      b <- rational_generator(),
+      c <- rational_generator() do
+      assert (a + b) + c == a + (b + c)
+    end
+  end
+
+
+  property "Additive identity" do
+    check all a <- rational_generator() do
+      assert a + 0 == a
+      assert 0 + a == a
+    end
+  end
+
+  property "Additive inverse" do
+    check all a <- rational_generator() do
+      inverse = Ratio.new(-a.numerator, a.denominator)
+      assert a + inverse == Ratio.new(0)
+      assert inverse + a == Ratio.new(0)
+    end
+  end
+
+  property "Subtraction is closed" do
+    check all a <- rational_generator(),
+      b <- rational_generator() do
+      assert is_rational(a - b)
+    end
+  end
+
+  property "Subtractive inverse" do
+    check all a <- rational_generator() do
+      inverse = Ratio.new(-a.numerator, a.denominator)
+      assert 0 - inverse == a
+      assert 0 - a == inverse
+    end
+  end
+
+  property "Multiplication is closed" do
+    check all a <- rational_generator(),
+      b <- rational_generator() do
+      assert is_rational(a * b)
+    end
+  end
+
+  property "Multiplication is commutative" do
+    check all a <- rational_generator(),
+      b <- rational_generator() do
+      assert a * b == b * a
+    end
+  end
+
+  property "Multiplication is associative" do
+    check all a <- rational_generator(),
+      b <- rational_generator(),
+      c <- rational_generator() do
+      assert (a * b) * c == a * (b * c)
+    end
+  end
+
+  property "Multiplicative identity" do
+    check all a <- rational_generator() do
+      assert a * 1 == a
+      assert 1 * a == a
+    end
+  end
+
+  property "Multiplication by zero is always zero" do
+    check all a <- rational_generator() do
+      assert a * 0 == Ratio.new(0)
+      assert 0 * a == Ratio.new(0)
+    end
+  end
+
+  property "Division is closed" do
+    check all a <- rational_generator(),
+      b <- rational_generator(),
+      b != Ratio.new(0) do
+      assert is_rational(a / b)
+    end
+  end
+
+  property "Multiplication distributes over Addition" do
+    check all a <- rational_generator(),
+      b <- rational_generator(),
+      c <- rational_generator() do
+      assert a * (b + c) == a * b + a * c
+    end
+  end
+
+  property "Multiplication distributes over Subtraction" do
+    check all a <- rational_generator(),
+      b <- rational_generator(),
+      c <- rational_generator() do
+      assert a * (b - c) == a * b - a * c
+    end
   end
 end

--- a/test/ratio/numbers_test.exs
+++ b/test/ratio/numbers_test.exs
@@ -17,5 +17,4 @@ defmodule Ratio.NumbersTest do
       assert Ratio.unquote(operation)(Ratio.new(1, 2), 3) == N.unquote(operation)(Ratio.new(1, 2), 3)
     end
   end
-
 end

--- a/test/ratio_test.exs
+++ b/test/ratio_test.exs
@@ -99,4 +99,68 @@ defmodule RatioTest do
       assert Ratio.sub(Ratio.new(0), a) == inverse
     end
   end
+
+  property "Multiplication is closed" do
+    check all a <- rational_generator(),
+      b <- rational_generator() do
+      assert is_rational(Ratio.mult(a, b))
+    end
+  end
+
+  property "Multiplication is commutative" do
+    check all a <- rational_generator(),
+      b <- rational_generator() do
+      assert Ratio.mult(a, b) == Ratio.mult(b, a)
+    end
+  end
+
+  property "Multiplication is associative" do
+    check all a <- rational_generator(),
+      b <- rational_generator(),
+      c <- rational_generator() do
+      assert Ratio.mult(Ratio.mult(a, b), c) == Ratio.mult(a, Ratio.mult(b, c))
+    end
+  end
+
+  property "Multiplicative identity" do
+    check all a <- rational_generator() do
+      assert Ratio.mult(a, Ratio.new(1)) == a
+      assert Ratio.mult(Ratio.new(1), a) == a
+    end
+  end
+
+  property "Multiplication by zero is always zero" do
+    check all a <- rational_generator() do
+      assert Ratio.mult(a, Ratio.new(0)) == Ratio.new(0)
+      assert Ratio.mult(Ratio.new(0), a) == Ratio.new(0)
+    end
+  end
+
+  property "Division is closed" do
+    check all a <- rational_generator(),
+      b <- rational_generator(),
+      b != Ratio.new(0) do
+      assert is_rational(Ratio.div(a, b))
+    end
+  end
+
+  property "Multiplication distributes over Addition" do
+    check all a <- rational_generator(),
+      b <- rational_generator(),
+      c <- rational_generator() do
+      left = Ratio.mult(a, Ratio.add(b, c))
+      right = Ratio.add(Ratio.mult(a, b), Ratio.mult(a, c))
+      assert left == right
+    end
+  end
+
+  property "Multiplication distributes over Subtraction" do
+    check all a <- rational_generator(),
+      b <- rational_generator(),
+      c <- rational_generator() do
+      left = Ratio.mult(a, Ratio.sub(b, c))
+      right = Ratio.sub(Ratio.mult(a, b), Ratio.mult(a, c))
+      assert left == right
+    end
+  end
 end

--- a/test/ratio_test.exs
+++ b/test/ratio_test.exs
@@ -8,15 +8,6 @@ defmodule RatioTest do
     assert 1 <|> 3 == %Ratio{numerator: 1, denominator: 3}
   end
 
-  if Code.ensure_loaded?(Decimal) do
-    test "decimal conversion" do
-      assert 15432 <|> 125 == Ratio.new(Decimal.new("123.456"))
-      assert 617 <|> 2839 == Ratio.new(Decimal.new("1234"), Decimal.new("5678"))
-      assert 617 <|> 2839 == Ratio.new(1234, Decimal.new("5678"))
-      assert 617 <|> 2839 == Ratio.new(Decimal.new("1234"), 5678)
-    end
-  end
-
   test "reject _ <|> 0" do
     assert_raise ArithmeticError, fn -> 1 <|> 0 end
     assert_raise ArithmeticError, fn -> 1234 <|> 0 end

--- a/test/ratio_test.exs
+++ b/test/ratio_test.exs
@@ -1,6 +1,6 @@
 defmodule RatioTest do
   use ExUnit.Case, async: true
-  use Ratio, comparison: true
+  import Ratio, only: [<|>: 2]
   doctest Ratio
   doctest Ratio.FloatConversion
 

--- a/test/ratio_test.exs
+++ b/test/ratio_test.exs
@@ -47,17 +47,56 @@ defmodule RatioTest do
     refute Ratio.equal?(1 <|> 3, 1 <|> 4)
   end
 
-  property "Ratio.plus has the closure property" do
+  property "Addition is closed" do
     check all a <- rational_generator(),
-              b <- rational_generator() do
+      b <- rational_generator() do
       assert is_rational(Ratio.add(a, b))
     end
   end
 
-    property "Ratio.plus is commutative" do
-      check all a <- rational_generator(),
-                b <- rational_generator() do
-        assert Ratio.add(a, b) == Ratio.add(b, a)
-      end
+  property "Addition is commutative" do
+    check all a <- rational_generator(),
+      b <- rational_generator() do
+      assert Ratio.add(a, b) == Ratio.add(b, a)
     end
+  end
+
+  property "Addition is associative" do
+    check all a <- rational_generator(),
+      b <- rational_generator(),
+      c <- rational_generator() do
+      assert Ratio.add(Ratio.add(a, b), c) == Ratio.add(a, Ratio.add(b, c))
+    end
+  end
+
+
+  property "Additive identity" do
+    check all a <- rational_generator() do
+      assert Ratio.add(a, Ratio.new(0)) == a
+      assert Ratio.add(Ratio.new(0), a) == a
+    end
+  end
+
+  property "Additive inverse" do
+    check all a <- rational_generator() do
+      inverse = Ratio.new(-a.numerator, a.denominator)
+      assert Ratio.add(a, inverse) == Ratio.new(0)
+      assert Ratio.add(inverse, a) == Ratio.new(0)
+    end
+  end
+
+  property "Subtraction is closed" do
+    check all a <- rational_generator(),
+      b <- rational_generator() do
+      assert is_rational(Ratio.sub(a, b))
+    end
+  end
+
+  property "Subtractive inverse" do
+    check all a <- rational_generator() do
+      inverse = Ratio.new(-a.numerator, a.denominator)
+      assert Ratio.sub(Ratio.new(0), inverse) == a
+      assert Ratio.sub(Ratio.new(0), a) == inverse
+    end
+  end
 end

--- a/test/ratio_test.exs
+++ b/test/ratio_test.exs
@@ -1,6 +1,9 @@
 defmodule RatioTest do
   use ExUnit.Case, async: true
-  import Ratio, only: [<|>: 2]
+  use ExUnitProperties
+  import TestHelper
+
+  import Ratio, only: [<|>: 2, is_rational: 1]
   doctest Ratio
   doctest Ratio.FloatConversion
 
@@ -43,4 +46,18 @@ defmodule RatioTest do
     assert Ratio.equal?(1 <|> 3, 1 <|> 3)
     refute Ratio.equal?(1 <|> 3, 1 <|> 4)
   end
+
+  property "Ratio.plus has the closure property" do
+    check all a <- rational_generator(),
+              b <- rational_generator() do
+      assert is_rational(Ratio.add(a, b))
+    end
+  end
+
+    property "Ratio.plus is commutative" do
+      check all a <- rational_generator(),
+                b <- rational_generator() do
+        assert Ratio.add(a, b) == Ratio.add(b, a)
+      end
+    end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,13 @@
 ExUnit.start()
+
+require ExUnitProperties
+
+defmodule TestHelper do
+  def rational_generator do
+    ExUnitProperties.gen all  numerator <- StreamData.integer,
+      denominator <- StreamData.integer,
+      denominator != 0 do
+      Ratio.new(numerator, denominator)
+    end
+  end
+end


### PR DESCRIPTION
This PR implements a rigorous rewrite, and introduces some breaking changes:

- [x] All operators except `<|>/2` are removed from `Ratio`. Fixes #34 .
- [x] Operators can still be used by depending on `Numbers` instead, which `Ratio` implements.
- [x] The math-based functions inside `Ratio` itself expect a rational struct as both arguments. This cleans up the code considerably and speeds up common cases. If automatic casting is desired, use `Numbers` instead (which is a bit slower because it is more dynamic).
- [x] Property-based tests are now in place to make sure the library functions as expected.
- [x] `is_rational?` is replaced by the guard-safe `is_rational` (it only is exported on OTP versions that have the `:erlang.map_get` guard available).
- [ ] Floats are now imported strictly, rather than rounded using some not-so-clear heuristics. (Fixes #26 )
