### PR TITLE
fix serious integer incompatiblilty

### DIFF
--- a/lib/ratio/float_conversion.ex
+++ b/lib/ratio/float_conversion.ex
@@ -9,7 +9,7 @@ defmodule Ratio.FloatConversion do
   ## Examples
 
       iex> Ratio.FloatConversion.float_to_rational(10.0)
-      10
+      10 <|> 1
       iex> Ratio.FloatConversion.float_to_rational(13.5)
       27 <|> 2
       iex> Ratio.FloatConversion.float_to_rational(1.1)
@@ -17,10 +17,7 @@ defmodule Ratio.FloatConversion do
   """
 
   def float_to_rational(float) do
-    ratio = Float.ratio(float)
-    case ratio do
-      {numerator, 1} -> numerator
-      {numerator, denominator} -> numerator <|> denominator
-    end
+    {numerator, denominator} = Float.ratio(float)
+    numerator <|> denominator
   end
 end


### PR DESCRIPTION
float_to_rational should return rational structure even if denominator is 1. Previous PR contained error that it returned 10 instead of 10 <|> 1 for Ratio.new(10.0)