### PR TITLE
Fixed bug when ceiling a number with denominator == 1.

### DIFF
--- a/lib/ratio.ex
+++ b/lib/ratio.ex
@@ -562,7 +562,7 @@ defmodule Ratio do
   def ceil(num = %Ratio{numerator: numerator, denominator: denominator}) do
     floor = Ratio.floor(num)
 
-    if numerator <|> denominator == floor do
+    if eq?(numerator <|> denominator, floor) do
       floor
     else
       floor + 1

--- a/mix.exs
+++ b/mix.exs
@@ -53,7 +53,7 @@ defmodule Rational.Mixfile do
       {:numbers, "~> 5.2.0"},
       # If Decimal number support is required
       {:decimal, "~> 1.6 or ~> 2.0", optional: true},
-      {:stream_data, "~> 0.1", only: :test}
+      {:stream_data, "~> 0.1", only: [:dev, :test]}
     ]
   end
 
@@ -76,8 +76,8 @@ defmodule Rational.Mixfile do
     [
       main: "readme",
       extras: [
-        "README.md": [title: "Guide/Readme"],
-      ],
+        "README.md": [title: "Guide/Readme"]
+      ]
     ]
   end
 end

--- a/test/ratio/float_conversion_test.exs
+++ b/test/ratio/float_conversion_test.exs
@@ -4,7 +4,7 @@ defmodule Ratio.FloatConversionTest do
   # use Ratio coerces negative floats to Ratios, so the below test needs to be run outside the Ratio.FloatConversion
   # module.
   test "float conversion for negative numbers" do
-    assert %Ratio{numerator: -2476979795053773, denominator: 2251799813685248} ==
+    assert %Ratio{numerator: -2_476_979_795_053_773, denominator: 2_251_799_813_685_248} ==
              Ratio.FloatConversion.float_to_rational(-1.1)
   end
 end

--- a/test/ratio_test.exs
+++ b/test/ratio_test.exs
@@ -48,8 +48,15 @@ defmodule RatioTest do
   end
 
   test "small number precision" do
-    assert Ratio.equal?(Ratio.new(1.602177E-19), 1663795720783351 <|> 10384593717069655257060992658440192)
-    assert Ratio.equal?(Ratio.new(1.49241808560E-10), 5773512823493363 <|> 38685626227668133590597632)
+    assert Ratio.equal?(
+             Ratio.new(1.602177e-19),
+             1_663_795_720_783_351 <|> 10_384_593_717_069_655_257_060_992_658_440_192
+           )
+
+    assert Ratio.equal?(
+             Ratio.new(1.49241808560e-10),
+             5_773_512_823_493_363 <|> 38_685_626_227_668_133_590_597_632
+           )
   end
 
   property "Addition is closed" do
@@ -166,5 +173,10 @@ defmodule RatioTest do
       right = Ratio.sub(Ratio.mult(a, b), Ratio.mult(a, c))
       assert left == right
     end
+  end
+
+  test "When ceiling a number with denominator 1 it returns nominator" do
+    # https://github.com/Qqwy/elixir-rational/issues/89#issuecomment-1139664334
+    assert Ratio.new(400) |> Ratio.ceil() == 400
   end
 end


### PR DESCRIPTION
- Fixes a bug in ceil, https://github.com/Qqwy/elixir-rational/issues/89
- Fixes crashing elixir_ls in VSCode

Closes #89 