### PR TITLE
Continued fraction representation of rationals for valid comparison

### DIFF
--- a/test/ratio/float_conversion_test.exs
+++ b/test/ratio/float_conversion_test.exs
@@ -4,7 +4,7 @@ defmodule Ratio.FloatConversionTest do
   # use Ratio coerces negative floats to Ratios, so the below test needs to be run outside the Ratio.FloatConversion
   # module.
   test "float conversion for negative numbers" do
-    assert %Ratio{numerator: -2_476_979_795_053_773, denominator: 2_251_799_813_685_248} ==
+    assert %Ratio{numerator: -2_476_979_795_053_773, denominator: 2_251_799_813_685_248, continued_fraction_representation: [-1, 9, -1, 112589990684261, -2]} ==
              Ratio.FloatConversion.float_to_rational(-1.1)
   end
 end

--- a/test/ratio/float_conversion_test.exs
+++ b/test/ratio/float_conversion_test.exs
@@ -4,7 +4,11 @@ defmodule Ratio.FloatConversionTest do
   # use Ratio coerces negative floats to Ratios, so the below test needs to be run outside the Ratio.FloatConversion
   # module.
   test "float conversion for negative numbers" do
-    assert %Ratio{numerator: -2_476_979_795_053_773, denominator: 2_251_799_813_685_248, continued_fraction_representation: [-1, 9, -1, 112589990684261, -2]} ==
+    assert %Ratio{
+             numerator: -2_476_979_795_053_773,
+             denominator: 2_251_799_813_685_248,
+             continued_fraction_representation: [-1, -1, 9, -1, 112_589_990_684_261, -2]
+           } ==
              Ratio.FloatConversion.float_to_rational(-1.1)
   end
 end

--- a/test/ratio_test.exs
+++ b/test/ratio_test.exs
@@ -8,7 +8,7 @@ defmodule RatioTest do
   doctest Ratio.FloatConversion
 
   test "definition of <|> operator" do
-    assert 1 <|> 3 == %Ratio{numerator: 1, denominator: 3}
+    assert 1 <|> 3 == %Ratio{numerator: 1, denominator: 3, continued_fraction_representation: [0, -3]}
   end
 
   test "reject _ <|> 0" do

--- a/test/ratio_test.exs
+++ b/test/ratio_test.exs
@@ -8,7 +8,11 @@ defmodule RatioTest do
   doctest Ratio.FloatConversion
 
   test "definition of <|> operator" do
-    assert 1 <|> 3 == %Ratio{numerator: 1, denominator: 3, continued_fraction_representation: [0, -3]}
+    assert 1 <|> 3 == %Ratio{
+             numerator: 1,
+             denominator: 3,
+             continued_fraction_representation: [1, 0, -3]
+           }
   end
 
   test "reject _ <|> 0" do
@@ -45,6 +49,18 @@ defmodule RatioTest do
 
     assert Ratio.equal?(1 <|> 3, 1 <|> 3)
     refute Ratio.equal?(1 <|> 3, 1 <|> 4)
+  end
+
+  test "implicit comparison operators" do
+    assert 1 <|> 2 > 1 <|> 3
+    assert -1 <|> 2 < 1 <|> 3
+    assert 1 <|> 2 > -1 <|> 3
+    assert -1 <|> 2 < -1 <|> 3
+
+    assert Ratio.new(-2.3) > Ratio.new(-5.1)
+    assert Ratio.new(2.3) > Ratio.new(-5.1)
+    assert Ratio.new(-2.3) < Ratio.new(5.1)
+    assert Ratio.new(2.3) < Ratio.new(5.1)
   end
 
   test "small number precision" do


### PR DESCRIPTION
Hello, I've been facing an issue with the way the rationals are compared with the use of `Kernel.</2` and other comparison operators. 

**The problem**
Since in Elixir each term can be compared with any other term, I do not get any warning that the comparison of two rationals might not work as expected. Furthermore, since structs are compared field by field, I get the wrong result when comparing, i.e.: `%Ratio{numerator: 2, denominator: 100}` and `%Ratio{numerator: 1, denominator: 3}`. I know there is `Ratio.compare/2` function designed for such a comparison, but in the project, I've been working on we have faced some bugs due to the comparison occurring with comparison operators. 

**The solution**
I have found a way to represent a rational in a way that would allow comparing them properly with the use of `Kernel` comparison operators. That representation is called ['continued fraction'](https://cp-algorithms.com/algebra/continued-fractions.html) representation.
Continued fractions allow representing a real number as a sequence (potentially infinite) of integers `a_1, a_2, ...a_n`, which value is equal to:

![image](https://user-images.githubusercontent.com/10851084/177545845-7478d10b-03bb-48f1-8785-826d32535e47.png)


For rational numbers, this sequence is always finite, which allows us to store it in the form of a list.
The comparison of a positive rational represented by such a list can be done in the following way:
> Assume, that we have two rationals represented as continued fractions: a = [a_0, a_1, … , a_i] and b = [b_0, b_1, … , b_j].

> Let k be the index, where the sequences describing the rationals differ for the first time. Then:
>  - if k mod 2 == 0 then a > b when a_k > b_k and otherwise a < b 
> - if k mod == 1 then a > b when a_k < b_k and otherwise a > b
> (Note, that when a == b, there is no such a k that a_k != b_k)

The way the continued fractions are compared leads us to a convenient way to represent them, so that they can be compared with default Elixir's behavior, by the comparison operators. For `a = [a_0, a_1, ... a_i]` we will store `a_k` on k-th position if `k mod 2 == 0` and we will store `-a_k` (the negation of the a_k) if `k mod 2 == 1`

In order to represent all rational numbers, both the positive and negative ones, we can append a number from the {-1, 0, 1} set at the beginning of the list. That number would represent the sign of a rational.
 
**Some estimations concerning the complexity of such a representation**
The length of a sequence for a rational number p/q is: O(log(min(p, q)).
The value of the greatest coefficient in the sequence is limited by the min(p, q) expression. That means, that each coefficient can be written on O(log(min(p, q)) bits. This leads us to the final estimation of memory complexity of such a representation, being: log^2(min(p, q)).
The computational complexity of calculating a continued fraction representation for the p/q rational is the same as for the Euclidean Algorithm - O(log(min(p, q)). However, the representation can be calculated during the calculation of GCD (which is already done after almost each arithmetic operation, in order to simplify the expression) - therefore there is almost no computation overhead.

**PR purpose**
I have implemented the described solution and I introduce it within that PR. I am aware, that comparing a rational and i.e. an integer still won't produce a valid result (which isn't a problem that we face in our project, since we only need to compare rationals). Perhaps there is a possibility to extend that approach and make the rationals properly comparable with other numerical types.