### PR TITLE
Fix compilation warnings for elixir-v1.16

### DIFF
--- a/lib/ratio/coerce.ex
+++ b/lib/ratio/coerce.ex
@@ -12,8 +12,10 @@ Coerce.defcoercion Ratio, Float do
   end
 end
 
-Coerce.defcoercion Ratio, Decimal do
-  def coerce(ratio, decimal) do
-    {ratio, Ratio.DecimalConversion.decimal_to_rational(decimal)}
+if Code.ensure_loaded?(Decimal) do
+  Coerce.defcoercion Ratio, Decimal do
+    def coerce(ratio, decimal) do
+      {ratio, Ratio.DecimalConversion.decimal_to_rational(decimal)}
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -21,15 +21,12 @@ defmodule Rational.Mixfile do
   # Type "mix help compile.app" for more information
   def application do
     extra_applications =
-      case Mix.env() do
-        :test -> [:stream_data, :logger]
-        _ -> [:logger]
+      [:numbers, :logger] ++ case Mix.env() do
+        :test -> [:stream_data]
+        _ -> []
       end
 
     [
-      applications: [
-        :numbers
-      ],
       extra_applications: extra_applications
     ]
   end


### PR DESCRIPTION
The PR updates two simple things, the use of `:applications` alongside `:extra_applications` in `mix.exs`, producing a warning as of elixir 1.16.0 that it `:applications` is redundant.

The other is making sure that the function in `coerce.ex` pertaining to the use of the `:decimal` optional dependency is wrapped in a `ensure_loaded?/1` in the same manner that all of `decimal_conversion.ex` is. Otherwise, it is included in the compiled code, but referring to a non-existent function. This also generates a warning.

The documentation below is not necessary to review this PR, it describes the use case that motivates my contribution and contains the compilation warnings mentioned.

---------
The objective is to redirect all logging done by `Mix.install` inside an elixir script, so that the rest of the script is the sole instance writing to `stdout` and may be used in UNIX pipelines. This was achievable with the use of `Mix.Shell.Quiet`, and most warnings were logged to `stderr` anyway, but this seems to have changed as of elixir 1.16

Consider a simple `Hello world`. The expected output is solely 'Hello!'.

```elixir
Mix.start()
Mix.shell(Mix.Shell.Quiet)

Mix.install([{:ratio, "~> 4.0", force: true}])

IO.puts("Hello!")

```
```console
root@0f55d10b9e84:/workspace/membrane/elixir-rational:λ> asdf global elixir 1.15.5-otp-26
root@0f55d10b9e84:/workspace/membrane/elixir-rational:λ> /bin/rm -rf ~/.cache && elixir script.exs
warning: Ratio.DecimalConversion.decimal_to_rational/1 is undefined (module Ratio.DecimalConversion is not available or is yet to be defined)
  lib/ratio/coerce.ex:17: Coerce.Implementations.Ratio.Decimal.coerce/2

Hello!
root@0f55d10b9e84:/workspace/membrane/elixir-rational:λ> /bin/rm -rf ~/.cache && elixir script.exs 2> /dev/null
Hello!
root@0f55d10b9e84:/workspace/membrane/elixir-rational:λ> asdf global elixir 1.16.0-otp-26
root@0f55d10b9e84:/workspace/membrane/elixir-rational:λ> /bin/rm -rf ~/.cache && elixir script.exs
    warning: Ratio.DecimalConversion.decimal_to_rational/1 is undefined (module Ratio.DecimalConversion is not available or is yet to be defined)
    │
 17 │     {ratio, Ratio.DecimalConversion.decimal_to_rational(decimal)}
    │                                     ~
    │
    └─ lib/ratio/coerce.ex:17:37: Coerce.Implementations.Ratio.Decimal.coerce/2

==> ratio
both :extra_applications and :applications was found in your mix.exs. You most likely want to remove the :applications key, as all applications are derived from your dependencies
Hello!
root@0f55d10b9e84:/workspace/membrane/elixir-rational:λ> /bin/rm -rf ~/.cache && elixir script.exs 2> /dev/null
==> ratio
Hello!
root@0f55d10b9e84:/workspace/membrane/elixir-rational:λ>
```

After applying the changes included in this PR:
```elixir
Mix.start()
Mix.shell(Mix.Shell.Quiet)

Mix.install([{:ratio, path: ".", force: true}])

IO.puts("Hello!")
```
```console
root@0f55d10b9e84:/workspace/membrane/elixir-rational:λ> mix clean --all && mix deps.clean --all  # to be extra sure
root@0f55d10b9e84:/workspace/membrane/elixir-rational:λ> echo $?
0
root@0f55d10b9e84:/workspace/membrane/elixir-rational:λ> asdf global elixir 1.15.5-otp-26
root@0f55d10b9e84:/workspace/membrane/elixir-rational:λ> /bin/rm -rf ~/.cache && elixir script.exs
Hello!
root@0f55d10b9e84:/workspace/membrane/elixir-rational:λ> /bin/rm -rf ~/.cache && elixir script.exs 2> /dev/null
Hello!
root@0f55d10b9e84:/workspace/membrane/elixir-rational:λ> asdf global elixir 1.16.0-otp-26
root@0f55d10b9e84:/workspace/membrane/elixir-rational:λ> /bin/rm -rf ~/.cache && elixir script.exs
Hello!
root@0f55d10b9e84:/workspace/membrane/elixir-rational:λ> /bin/rm -rf ~/.cache && elixir script.exs 2> /dev/null
Hello!
root@0f55d10b9e84:/workspace/membrane/elixir-rational:λ>
```